### PR TITLE
install rails_12factor to fix devise signout on heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,9 +56,6 @@ group :development do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-
-
-
 end
 
 # Rspec for testing
@@ -67,3 +64,4 @@ group :development, :test do
   gem "database_cleaner"
 end
 
+gem 'rails_12factor', group: :production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,11 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.4)
+    rails_stdout_logging (0.0.4)
     railties (4.2.4)
       actionpack (= 4.2.4)
       activesupport (= 4.2.4)
@@ -237,6 +242,7 @@ DEPENDENCIES
   pg
   pry-rails
   rails (= 4.2.4)
+  rails_12factor
   rspec-rails (~> 3.0)
   rubocop
   sass-rails (~> 5.0)


### PR DESCRIPTION
When we sign out on Heroku, we get this The page...doesn't exist error. Installing rails_12factor should resolve this for production.

http://stackoverflow.com/questions/23073737/sign-out-not-working-on-heroku-using-devise-gem-and-rails-4